### PR TITLE
Changes to pg_repack.pp per SUP-1949

### DIFF
--- a/spec/classes/maintenance/pg_repack_spec.rb
+++ b/spec/classes/maintenance/pg_repack_spec.rb
@@ -7,48 +7,68 @@ describe 'pe_databases::maintenance::pg_repack' do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
-      context 'on PE 2019.1.0' do
+      context 'on < PE 2019.3.0' do
         before :each do
           facts['pe_server_version'] = '2019.1.0'
           facts['pe_postgresql_info']['installed_server_version'] = 9.6
         end
         it {
-          is_expected.to contain_cron('pg_repack reports tables')
+          is_expected.to contain_cron('pg_repack resource_events tables')
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/9.6/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t reports -t resource_events" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+            ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
         }
-      end
-      context 'on > PE 2019.1.0' do
-        before :each do
-          facts['pe_server_version'] = '2019.2.0'
-          facts['pe_postgresql_info']['installed_server_version'] = 9.6
-        end
         it {
           is_expected.to contain_cron('pg_repack reports tables')
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/9.6/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t reports -t resource_events" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+            ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
         }
       end
-      context 'on < PE 2019.1.0' do
-        before :each do
-          facts['pe_server_version'] = '2019.0.0'
-          facts['pe_postgresql_info']['installed_server_version'] = 9.6
-        end
-        it {
-          is_expected.to contain_cron('pg_repack reports tables')
-            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
-        }
-      end
-      context 'on > PE 2019.1.0 with postgresql 11' do
+      context 'on < PE 2019.3.0 with postgresql 11' do
         before :each do
           facts['pe_server_version'] = '2019.2.0'
           facts['pe_postgresql_info']['installed_server_version'] = 11
         end
         it {
+          is_expected.to contain_cron('pg_repack resource_events tables')
+            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+        }
+        it {
           is_expected.to contain_cron('pg_repack reports tables')
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t reports -t resource_events" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+        }
+      end
+      context 'on < PE 2019.7.0' do
+        before :each do
+          facts['pe_server_version'] = '2019.5.0'
+          facts['pe_postgresql_info']['installed_server_version'] = 11
+        end
+        it {
+          is_expected.to contain_cron('pg_repack reports tables')
+            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+        }
+        it {
+          is_expected.not_to contain_cron('pg_repack resource_events tables')
+            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+        }
+      end
+      context 'on >= PE 2019.7.0' do
+        before :each do
+          facts['pe_server_version'] = '2019.7.0'
+          facts['pe_postgresql_info']['installed_server_version'] = 11
+        end
+        it {
+          is_expected.not_to contain_cron('pg_repack reports tables')
+            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+        }
+        it {
+          is_expected.not_to contain_cron('pg_repack resource_events tables')
+            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
         }
       end
     end


### PR DESCRIPTION
Changes to pg_repack.pp to prevent creation of cron jobs for the resource_events table in 2019.3+ and the reports table in 2019.7+; as a result of the DELETE operation no longer running against these tables.