### PR TITLE
(GH-30) Update repack logging to separate files

### DIFF
--- a/spec/classes/maintenance/pg_repack_spec.rb
+++ b/spec/classes/maintenance/pg_repack_spec.rb
@@ -15,12 +15,12 @@ describe 'pe_databases::maintenance::pg_repack' do
         it {
           is_expected.to contain_cron('pg_repack resource_events tables')
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/9.6/bin/pg_repack'\
-            ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+            ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
         }
         it {
           is_expected.to contain_cron('pg_repack reports tables')
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/9.6/bin/pg_repack'\
-            ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+            ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
         }
       end
       context 'on < PE 2019.3.0 with postgresql 11' do
@@ -31,12 +31,12 @@ describe 'pe_databases::maintenance::pg_repack' do
         it {
           is_expected.to contain_cron('pg_repack resource_events tables')
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+              ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
         }
         it {
           is_expected.to contain_cron('pg_repack reports tables')
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
         }
       end
       context 'on < PE 2019.7.0' do
@@ -47,12 +47,12 @@ describe 'pe_databases::maintenance::pg_repack' do
         it {
           is_expected.to contain_cron('pg_repack reports tables')
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
         }
         it {
           is_expected.not_to contain_cron('pg_repack resource_events tables')
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+              ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
         }
       end
       context 'on >= PE 2019.7.0' do
@@ -63,12 +63,12 @@ describe 'pe_databases::maintenance::pg_repack' do
         it {
           is_expected.not_to contain_cron('pg_repack reports tables')
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
         }
         it {
           is_expected.not_to contain_cron('pg_repack resource_events tables')
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/output.log 2>&1')
+              ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
         }
       end
     end


### PR DESCRIPTION
Prior to this commit, the repack maintenance jobs would all log to
`output.log` and clobber the log each time a job ran. This commit moves
the logs for each repack into their own file so they do not overwrite
other repack jobs logs.