### PR TITLE
(PDB-4881) Repack catalog_inputs on PE >= 2019.8.2

### DIFF
--- a/manifests/maintenance/pg_repack.pp
+++ b/manifests/maintenance/pg_repack.pp
@@ -30,6 +30,7 @@ class pe_databases::maintenance::pg_repack (
   $other_tables    = '-t producers -t resource_params -t resource_params_cache"'
   $reports_table   = '-t reports"'
   $resource_events_table = '-t resource_events"'
+  $catalog_inputs_table = '-t catalog_inputs"'
 
   Cron {
     ensure   => $ensure_cron,
@@ -82,6 +83,20 @@ class pe_databases::maintenance::pg_repack (
   }
   else {
     cron { 'pg_repack resource_events tables' :
+      ensure   => 'absent',
+    }
+  }
+
+  if versioncmp($facts['pe_server_version'], '2019.8.2') >= 0 {
+    cron { 'pg_repack catalog_inputs tables' :
+      weekday => [1,5],
+      hour    => 4,
+      minute  => 30,
+      command => "${repack} ${repack_jobs} ${catalog_inputs_table} > ${logging_directory}/catalog_inputs_repack.log 2>&1",
+    }
+  }
+  else {
+    cron { 'pg_repack catalog_inputs tables' :
       ensure   => 'absent',
     }
   }

--- a/spec/classes/maintenance/pg_repack_spec.rb
+++ b/spec/classes/maintenance/pg_repack_spec.rb
@@ -38,6 +38,11 @@ describe 'pe_databases::maintenance::pg_repack' do
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
               ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
         }
+        it {
+          is_expected.not_to contain_cron('pg_repack catalog_inputs tables')
+            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 -t catalog_inputs" > /var/log/puppetlabs/pe_databases_cron/catalog_inputs_repack.log 2>&1')
+        }
       end
       context 'on < PE 2019.7.0' do
         before :each do
@@ -69,6 +74,17 @@ describe 'pe_databases::maintenance::pg_repack' do
           is_expected.not_to contain_cron('pg_repack resource_events tables')
             .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
               ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
+        }
+      end
+      context 'on >= PE 2019.8.2' do
+        before :each do
+          facts['pe_server_version'] = '2019.8.2'
+          facts['pe_postgresql_info']['installed_server_version'] = 11
+        end
+        it {
+          is_expected.to contain_cron('pg_repack catalog_inputs tables')
+            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 -t catalog_inputs" > /var/log/puppetlabs/pe_databases_cron/catalog_inputs_repack.log 2>&1')
         }
       end
     end


### PR DESCRIPTION
This should at least wait to merge until we have merged https://github.com/puppetlabs/puppetdb/pull/3335, but may also need to wait until we release 2019.8.2. I don't know the details of this module.

Also I just picked a cron timer, and would love some feedback on it 
```
      weekday => [1,5],
      hour    => 4,
      minute  => 30,
```