### PR TITLE
(sup-2095) Remove cron_core from dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,10 +15,6 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.0.0 < 7.0.0"
-    },
-    {
-      "name": "puppetlabs-cron_core",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Prior to this commit, puppetlabs-cron_core was a dependency of this
module. Since cron_core is for Puppet 6+ and this module supports 5.5.x,
the cron_core module as a dependency is removed in this commit. The
cron_core module is provided in core puppet in 5.5.x and in the
puppet-agent package for 6.x, so there should not be a requirement to
install cron_core.