### PR TITLE
Increase the logging capabilities of the repacks

### DIFF
--- a/manifests/maintenance.pp
+++ b/manifests/maintenance.pp
@@ -4,6 +4,7 @@
 
 class pe_databases::maintenance (
   Boolean $disable_maintenance = false,
+  Boolean $disable_logrotate   = false,
   String  $logging_directory   = '/var/log/puppetlabs/pe_databases_cron',
   String  $log_level           = 'debug',
   String  $script_directory    = $pe_databases::scripts_dir,
@@ -28,5 +29,15 @@ class pe_databases::maintenance (
 
   file { $logging_directory :
     ensure => directory,
+  }
+
+  $logrotate_ensure = $disable_logrotate ? {
+    true    => 'absent',
+    default =>  'file'
+  }
+
+  file { '/etc/logrotate.d/pe_databases' :
+    ensure  => $logrotate_ensure,
+    content => epp('pe_databases/logrotate.epp', { 'logging_directory' => $logging_directory })
   }
 }

--- a/manifests/maintenance.pp
+++ b/manifests/maintenance.pp
@@ -5,6 +5,7 @@
 class pe_databases::maintenance (
   Boolean $disable_maintenance = false,
   String  $logging_directory   = '/var/log/puppetlabs/pe_databases_cron',
+  String  $log_level           = 'debug',
   String  $script_directory    = $pe_databases::scripts_dir,
 ){
 

--- a/manifests/maintenance/pg_repack.pp
+++ b/manifests/maintenance/pg_repack.pp
@@ -44,21 +44,21 @@ class pe_databases::maintenance::pg_repack (
     weekday => [2,6],
     hour    => 4,
     minute  => 30,
-    command => "${repack} ${args} ${facts_tables} ${repack_end} > ${logging_directory}/facts_repack.log 2>&1",
+    command => "${repack} ${args} ${facts_tables} ${repack_end} >> ${logging_directory}/facts_repack.log 2>&1",
   }
 
   cron { 'pg_repack catalogs tables' :
     weekday => [0,4],
     hour    => 4,
     minute  => 30,
-    command => "${repack} ${args} ${catalogs_tables} ${repack_end} > ${logging_directory}/catalogs_repack.log 2>&1",
+    command => "${repack} ${args} ${catalogs_tables} ${repack_end} >> ${logging_directory}/catalogs_repack.log 2>&1",
   }
 
   cron { 'pg_repack other tables' :
     monthday => 20,
     hour     => 5,
     minute   => 30,
-    command  => "${repack} ${args} ${other_tables} ${repack_end} > ${logging_directory}/other_repack.log 2>&1",
+    command  => "${repack} ${args} ${other_tables} ${repack_end} >> ${logging_directory}/other_repack.log 2>&1",
   }
 
   if versioncmp($facts['pe_server_version'], '2019.7.0') < 0 {
@@ -66,7 +66,7 @@ class pe_databases::maintenance::pg_repack (
       monthday => 10,
       hour     => 5,
       minute   => 30,
-      command  => "${repack} ${args} ${reports_table} ${repack_end} > ${logging_directory}/reports_repack.log 2>&1",
+      command  => "${repack} ${args} ${reports_table} ${repack_end} >> ${logging_directory}/reports_repack.log 2>&1",
     }
   }
   else {
@@ -80,7 +80,7 @@ class pe_databases::maintenance::pg_repack (
       monthday => 15,
       hour     => 5,
       minute   => 30,
-      command  => "${repack} ${args} ${resource_events_table} ${repack_end} > ${logging_directory}/resource_events_repack.log 2>&1",
+      command  => "${repack} ${args} ${resource_events_table} ${repack_end} >> ${logging_directory}/resource_events_repack.log 2>&1",
     }
   }
   else {

--- a/spec/classes/maintenance/pg_repack_spec.rb
+++ b/spec/classes/maintenance/pg_repack_spec.rb
@@ -14,13 +14,13 @@ describe 'pe_databases::maintenance::pg_repack' do
         end
         it {
           is_expected.to contain_cron('pg_repack resource_events tables')
-            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/9.6/bin/pg_repack'\
-            ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
+            .with_command('su - pe-postgres -s /bin/bash -c "date +%FT%T; /opt/puppetlabs/server/apps/postgresql/9.6/bin/pg_repack'\
+            ' -d pe-puppetdb --jobs 2 --elevel debug -t resource_events ; date +%FT%T;" >> /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
         }
         it {
           is_expected.to contain_cron('pg_repack reports tables')
-            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/9.6/bin/pg_repack'\
-            ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
+            .with_command('su - pe-postgres -s /bin/bash -c "date +%FT%T; /opt/puppetlabs/server/apps/postgresql/9.6/bin/pg_repack'\
+            ' -d pe-puppetdb --jobs 2 --elevel debug -t reports ; date +%FT%T;" >> /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
         }
       end
       context 'on < PE 2019.3.0 with postgresql 11' do
@@ -30,13 +30,13 @@ describe 'pe_databases::maintenance::pg_repack' do
         end
         it {
           is_expected.to contain_cron('pg_repack resource_events tables')
-            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
+            .with_command('su - pe-postgres -s /bin/bash -c "date +%FT%T; /opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 --elevel debug -t resource_events ; date +%FT%T;" >> /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
         }
         it {
           is_expected.to contain_cron('pg_repack reports tables')
-            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
+            .with_command('su - pe-postgres -s /bin/bash -c "date +%FT%T; /opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 --elevel debug -t reports ; date +%FT%T;" >> /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
         }
       end
       context 'on < PE 2019.7.0' do
@@ -46,13 +46,13 @@ describe 'pe_databases::maintenance::pg_repack' do
         end
         it {
           is_expected.to contain_cron('pg_repack reports tables')
-            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
+            .with_command('su - pe-postgres -s /bin/bash -c "date +%FT%T; /opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 --elevel debug -t reports ; date +%FT%T;" >> /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
         }
         it {
           is_expected.not_to contain_cron('pg_repack resource_events tables')
-            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
+            .with_command('su - pe-postgres -s /bin/bash -c "date +%FT%T; /opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 --elevel debug -t resource_events ; date +%FT%T;" >> /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
         }
       end
       context 'on >= PE 2019.7.0' do
@@ -62,13 +62,13 @@ describe 'pe_databases::maintenance::pg_repack' do
         end
         it {
           is_expected.not_to contain_cron('pg_repack reports tables')
-            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t reports" > /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
+            .with_command('su - pe-postgres -s /bin/bash -c "date +%FT%T; /opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 --elevel debug -t reports ; date +%FT%T;" >> /var/log/puppetlabs/pe_databases_cron/reports_repack.log 2>&1')
         }
         it {
           is_expected.not_to contain_cron('pg_repack resource_events tables')
-            .with_command('su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
-              ' -d pe-puppetdb --jobs 2 -t resource_events" > /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
+            .with_command('su - pe-postgres -s /bin/bash -c "date +%FT%T; /opt/puppetlabs/server/apps/postgresql/11/bin/pg_repack'\
+              ' -d pe-puppetdb --jobs 2 --elevel debug -t resource_events ; date +%FT%T;" >> /var/log/puppetlabs/pe_databases_cron/resource_events_repack.log 2>&1')
         }
       end
     end

--- a/spec/classes/maintenance_spec.rb
+++ b/spec/classes/maintenance_spec.rb
@@ -8,6 +8,8 @@ describe 'pe_databases::maintenance' do
 
       it { is_expected.to compile }
 
+      it { is_expected.to contain_file('/etc/logrotate.d/pe_databases') }
+
       context 'on PE 2019.0.0' do
         before(:each) do
           facts['pe_server_version'] = '2019.0.0'

--- a/templates/logrotate.epp
+++ b/templates/logrotate.epp
@@ -1,0 +1,8 @@
+<%- | String $logging_directory = $pe_databases::maintenance::logging_directory | -%>
+<%= $logging_directory -%>/*.log {
+    daily
+    missingok
+    rotate 16
+    compress
+    notifempty
+}


### PR DESCRIPTION
This PR adds log rotation through logrotate, increases the log level to debug, and adds timestamps around the cron job output. 

This is not the long term solution as we will want to go to systemd timers eventually but this allows for increased logging in the interim. 