### PR TITLE
(SUP-2374) Remove external module deps

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,4 @@
 ---
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib"
-    postgresql: "git://github.com/puppetlabs/puppetlabs-postgresql"
     cron_core: "git://github.com/puppetlabs/puppetlabs-cron_core"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,7 +43,7 @@ Style/BlockDelimiters:
 Style/BracesAroundHashParameters:
   Description: Braces are required by Ruby 2.7. Cop removed from RuboCop v0.80.0.
     See https://github.com/rubocop-hq/rubocop/pull/7643
-  Enabled: true
+  Enabled: false
 Style/ClassAndModuleChildren:
   Description: Compact style reduces the required amount of indentation.
   EnforcedStyle: compact

--- a/manifests/postgresql_settings.pp
+++ b/manifests/postgresql_settings.pp
@@ -55,7 +55,7 @@ class pe_databases::postgresql_settings (
   # https://tickets.puppetlabs.com/browse/MODULES-2960
   # http://www.postgresql.org/docs/9.4/static/runtime-config-autovacuum.html
 
-  Postgresql_conf {
+  Pe_postgresql_conf {
     ensure => present,
     target => "/opt/puppetlabs/server/data/postgresql/${psql_version}/data/postgresql.conf",
     notify => $notify_postgresql_service,

--- a/manifests/postgresql_settings.pp
+++ b/manifests/postgresql_settings.pp
@@ -61,43 +61,43 @@ class pe_databases::postgresql_settings (
     notify => $notify_postgresql_service,
   }
 
-  postgresql_conf { 'autovacuum_vacuum_scale_factor' :
+  pe_postgresql_conf { 'autovacuum_vacuum_scale_factor' :
     value => sprintf('%#.2f', $autovacuum_vacuum_scale_factor),
   }
 
-  postgresql_conf { 'autovacuum_analyze_scale_factor' :
+  pe_postgresql_conf { 'autovacuum_analyze_scale_factor' :
     value => sprintf('%#.2f', $autovacuum_analyze_scale_factor),
   }
 
-  postgresql_conf { 'autovacuum_max_workers' :
+  pe_postgresql_conf { 'autovacuum_max_workers' :
     value => String($autovacuum_max_workers),
   }
 
-  postgresql_conf { 'autovacuum_work_mem' :
+  pe_postgresql_conf { 'autovacuum_work_mem' :
     value => String($autovacuum_work_mem),
   }
 
-  postgresql_conf { 'log_autovacuum_min_duration' :
+  pe_postgresql_conf { 'log_autovacuum_min_duration' :
     value => String($log_autovacuum_min_duration),
   }
 
-  postgresql_conf { 'log_temp_files' :
+  pe_postgresql_conf { 'log_temp_files' :
     value => String($log_temp_files),
   }
 
-  postgresql_conf { 'maintenance_work_mem' :
+  pe_postgresql_conf { 'maintenance_work_mem' :
     value => String($maintenance_work_mem),
   }
 
-  postgresql_conf { 'work_mem' :
+  pe_postgresql_conf { 'work_mem' :
     value => String($work_mem),
   }
 
-  postgresql_conf { 'max_connections' :
+  pe_postgresql_conf { 'max_connections' :
     value => String($max_connections),
   }
 
-  postgresql_conf { 'checkpoint_completion_target' :
+  pe_postgresql_conf { 'checkpoint_completion_target' :
     value => sprintf('%#.2f', $checkpoint_completion_target),
   }
 
@@ -106,14 +106,14 @@ class pe_databases::postgresql_settings (
     default => 'absent',
   }
 
-  postgresql_conf { 'checkpoint_segments' :
+  pe_postgresql_conf { 'checkpoint_segments' :
     ensure => $checkpoint_segments_ensure,
     value  => String($checkpoint_segments),
   }
 
   if !empty($arbitrary_postgresql_conf_settings) {
     $arbitrary_postgresql_conf_settings.each | $key, $value | {
-      postgresql_conf { $key :
+      pe_postgresql_conf { $key :
         value => String($value),
       }
     }

--- a/manifests/set_table_attribute.pp
+++ b/manifests/set_table_attribute.pp
@@ -10,7 +10,7 @@ define pe_databases::set_table_attribute (
 ) {
 
   # lint:ignore:140chars
-  postgresql_psql { "Set ${table_attribute}=${table_attribute_value} for ${table_name}" :
+  pe_postgresql_psql { "Set ${table_attribute}=${table_attribute_value} for ${table_name}" :
     command    => "ALTER TABLE ${table_name} SET ( ${table_attribute} = ${table_attribute_value} )",
     unless     => "SELECT reloptions FROM pg_class WHERE relname = '${table_name}' AND CAST(reloptions as text) LIKE '%${table_attribute}=${table_attribute_value}%'",
     db         => $db,

--- a/metadata.json
+++ b/metadata.json
@@ -8,14 +8,6 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-pe_databases",
   "issues_url": "https://github.com/puppetlabs/puppetlabs-pe_databases/issues",
   "dependencies": [
-    {
-      "name": "puppetlabs-postgresql",
-      "version_requirement": ">= 4.7.0 < 7.0.0"
-    },
-    {
-      "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
-    }
   ],
   "operatingsystem_support": [
     {
@@ -73,7 +65,7 @@
       "version_requirement": ">= 5.5.0"
     }
   ],
-  "pdk-version": "1.18.1",
+  "pdk-version": "2.1.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "heads/master-0-gd610ead"
+  "template-ref": "remotes/origin/master-0-ga58fd92"
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,7 +2,11 @@ require 'spec_helper'
 
 describe 'pe_databases' do
   let(:params) do
-    {}
+    {
+      manage_database_backups:  false,
+      manage_postgresql_settings: false,
+      manage_table_settings:  false,
+    }
   end
 
   on_supported_os.each do |os, os_facts|

--- a/spec/classes/maintenance/pg_repack_spec.rb
+++ b/spec/classes/maintenance/pg_repack_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe 'pe_databases::maintenance::pg_repack' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:pre_condition) { "class { 'pe_databases': }" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }

--- a/spec/classes/maintenance/pg_repack_spec.rb
+++ b/spec/classes/maintenance/pg_repack_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'pe_databases::maintenance::pg_repack' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
+      let(:pre_condition) { "class { 'pe_databases': manage_database_backups =>  false, manage_postgresql_settings => false, manage_table_settings =>  false, }" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }

--- a/spec/classes/maintenance/vacuum_full_spec.rb
+++ b/spec/classes/maintenance/vacuum_full_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe 'pe_databases::maintenance::vacuum_full' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:pre_condition) { "class { 'pe_databases': }" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }

--- a/spec/classes/maintenance/vacuum_full_spec.rb
+++ b/spec/classes/maintenance/vacuum_full_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'pe_databases::maintenance::vacuum_full' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
+      let(:pre_condition) { "class { 'pe_databases': manage_database_backups =>  false, manage_postgresql_settings => false, manage_table_settings =>  false,}" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }

--- a/spec/classes/maintenance_spec.rb
+++ b/spec/classes/maintenance_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe 'pe_databases::maintenance' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:pre_condition) { "class { 'pe_databases': }" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }

--- a/spec/classes/maintenance_spec.rb
+++ b/spec/classes/maintenance_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'pe_databases::maintenance' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
+      let(:pre_condition) { "class { 'pe_databases': manage_database_backups =>  false, manage_postgresql_settings => false, manage_table_settings =>  false,}" }
       let(:facts) { os_facts }
 
       it { is_expected.to compile }


### PR DESCRIPTION
Prior to this commit, the module had dependencies for postgresql and stdlib.

stdlib appears to have been in metadata only, postgres functions are migrated to corresponding pe_postgres functions.

Passes local acceptance tests with pe_postgres module present, unsure as to how to perform spec testing utilising fixtures on internal repos in remote pipeline