### PR TITLE
(FEAT) Allow parameter for vacuum full

### DIFF
--- a/functions/has_pg_repack_available.pp
+++ b/functions/has_pg_repack_available.pp
@@ -1,0 +1,17 @@
+# Function: has_pg_repack_available
+#
+# Results:
+#
+# returns true if the system has pg_repack available and false if not.
+
+function pe_databases::has_pg_repack_available() >> Boolean {
+
+  if (versioncmp( '2018.1.7', $facts['pe_server_version']) <= 0 and versioncmp($facts['pe_server_version'], '2019.0.0') < 0 ) {
+    $has_pg_repack_available = true
+  } elsif ( versioncmp( '2019.0.2', $facts['pe_server_version']) <= 0 ) {
+    $has_pg_repack_available = true
+  } else {
+    $has_pg_repack_available = false
+  }
+
+}

--- a/manifests/maintenance.pp
+++ b/manifests/maintenance.pp
@@ -6,23 +6,24 @@ class pe_databases::maintenance (
   Boolean $disable_maintenance = false,
   String  $logging_directory   = '/var/log/puppetlabs/pe_databases_cron',
   String  $script_directory    = $pe_databases::scripts_dir,
+  Boolean $use_pg_repack       = pe_databases::has_pg_repack_available(),
 ){
 
   # If this version of PE includes pg_repack (2018.1.7 and 2019.0.2 and newer),
   # then use pg_repack and remove the old script and cron jobs.
+  # If the user specifies $use_pg_repack = false then use vacuum_full and
+  # make sure to remove the pg_repack cron jobs and scripts
 
-  if (versioncmp( '2018.1.7', $facts['pe_server_version']) <= 0 and versioncmp($facts['pe_server_version'], '2019.0.0') < 0 ) {
-    include pe_databases::maintenance::pg_repack
-    class { 'pe_databases::maintenance::vacuum_full':
-      disable_maintenance => true,
-    }
-  } elsif ( versioncmp( '2019.0.2', $facts['pe_server_version']) <= 0 ) {
+  if $use_pg_repack {
     include pe_databases::maintenance::pg_repack
     class { 'pe_databases::maintenance::vacuum_full':
       disable_maintenance => true,
     }
   } else {
     include pe_databases::maintenance::vacuum_full
+    class { 'pe_databases::maintenance::pg_repack':
+      disable_maintenance => true,
+    }
   }
 
   file { $logging_directory :


### PR DESCRIPTION
Prior to this commit, if pg_repack was available
we always used it as it was assumed to be better.

After this commit, we allow users to specify if they'd
like to use vacuum full instead for cases where pg_repack
is failing.  Since we no longer need to repack the
resource_events or reports tables running a vacuum
full on all of the smaller tables is likely not a
large problem.