### PR TITLE
(maint) Add the bolt streaming to acceptance tests

### DIFF
--- a/.github/workflows/pe_latest_testing.yml
+++ b/.github/workflows/pe_latest_testing.yml
@@ -129,8 +129,8 @@ jobs:
         echo INVENTORY_PATH=$FILE >> $GITHUB_ENV
     - name: Install PE
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'rake deploy_pe::provision_master' -- bundle exec bolt --tmpdir /tmp --log-level debug  --modulepath spec/fixtures/modules  -i ./$INVENTORY_PATH plan run deploy_pe::provision_master --params '{"version":"${{ matrix.collection }}","pe_settings":{"password":"puppetlabs", "configure_tuning": false}}'  --targets all
-  
+        buildevents cmd $TRACE_ID $STEP_ID 'rake deploy_pe::provision_master' -- bundle exec bolt --tmpdir /tmp --log-level debug  --modulepath spec/fixtures/modules  -i ./$INVENTORY_PATH plan run deploy_pe::provision_master --params '{"version":"${{ matrix.collection }}","pe_settings":{"password":"puppetlabs", "configure_tuning": false}}'  --targets all --stream
+
     - name: Install module
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_module' -- bundle exec rake 'litmus:install_module'

--- a/.github/workflows/pe_lts_testing.yml
+++ b/.github/workflows/pe_lts_testing.yml
@@ -129,8 +129,8 @@ jobs:
         echo INVENTORY_PATH=$FILE >> $GITHUB_ENV
     - name: Install PE
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'rake deploy_pe::provision_master' -- bundle exec bolt --tmpdir /tmp --log-level debug  --modulepath spec/fixtures/modules  -i ./$INVENTORY_PATH plan run deploy_pe::provision_master --params '{"version":"${{ matrix.collection }}","pe_settings":{"password":"puppetlabs", "configure_tuning": false}}'  --targets all
-  
+        buildevents cmd $TRACE_ID $STEP_ID 'rake deploy_pe::provision_master' -- bundle exec bolt --tmpdir /tmp --log-level debug  --modulepath spec/fixtures/modules  -i ./$INVENTORY_PATH plan run deploy_pe::provision_master --params '{"version":"${{ matrix.collection }}","pe_settings":{"password":"puppetlabs", "configure_tuning": false}}'  --targets all --stream
+
     - name: Install module
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_module' -- bundle exec rake 'litmus:install_module'


### PR DESCRIPTION
This commit adds the streaming capabilities to the acceptance testing
bolt provisioning. This allows for better insight into the acceptance
testing output when diagnosing issues with the testing.