### PR TITLE
(SUP-2545) Disable table maintenance by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class pe_databases (
   # Manage the state of the maintenance tasks, i.e. systemd services and timers
   Boolean $disable_maintenance         = lookup('pe_databases::disable_maintenance', {'default_value' => false}),
   Boolean $manage_postgresql_settings  = true,
-  Boolean $manage_table_settings       = true,
+  Boolean $manage_table_settings       = false,
   String  $install_dir                 = '/opt/puppetlabs/pe_databases',
   String  $scripts_dir                 = "${install_dir}/scripts"
 ) {


### PR DESCRIPTION
Prior to this commit, the default behavior was to manage various
postgresql settings such as autovacuum frequency.  However, this is not
possible during a PE upgrade because postgres is down.