### PR TITLE
(SUP-2677) Deprecate backup functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ It is not recommended to classify using a pre-existing node group in the PE Cons
 
 ### Backup Schedule
 
+> WARNING: The backup functionality in this module has been deprecated and will be removed in a future release. 
+Please refer to the [PE Backup and Restore documentation](https://puppet.com/docs/pe/latest/backing_up_and_restoring_pe.html) for details on how to backup.
+You should ensure the parameter `pe_databases::manage_database_backups` and any parameters from the `pe_databases::backup` class are removed from classification or hiera.
+You should also clean up associated crontab entries.
+
 Backups are not activated by default but can be enabled by setting the following parameter:
 
 Hiera classification example 
@@ -90,7 +95,12 @@ Those defaults change based on the `$all_in_one_pe` parameter.
 
 ## Backups
 
-This is the documentation for Pupet Enterprise backups:
+> WARNING: The backup functionality in this module has been deprecated and will be removed in a future release. 
+Please refer to the [PE Backup and Restore documentation](https://puppet.com/docs/pe/latest/backing_up_and_restoring_pe.html) for details on how to backup.
+You should ensure the parameter `pe_databases::manage_database_backups` and any parameters from the `pe_databases::backup` class are removed from classification or hiera.
+You should also clean up associated crontab entries.
+
+This is the documentation for Puppet Enterprise backups:
 
 https://puppet.com/docs/pe/latest/backing_up_and_restoring_pe.html
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,10 @@ class pe_databases (
         class { 'pe_databases::backup':
           disable_maintenance => ! $manage_database_backups,
         }
-        warning('The backup functionality in the pe_databases module has been deprecated and will be removed in a future release.')
+        notify { 'pe_databases_backup_deprecate_warn':
+        message  => 'The backup functionality in the pe_databases module has been deprecated and will be removed in a future release.',
+        loglevel => warning,
+        }
       }
     }
     else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,7 @@ class pe_databases (
         class { 'pe_databases::backup':
           disable_maintenance => ! $manage_database_backups,
         }
+        warning('The backup functionality in the pe_databases module has been deprecated and will be removed in a future release.')
       }
     }
     else {


### PR DESCRIPTION
Added a warning if the parameter `manage_database_backups` is defined to output a deprecated message.

This only outputs to puppetserver.log and not during agent runs:

`2021-09-23T11:33:26.289Z WARN  [qtp351210790-526] [puppetserver] Scope(Class[Pe_databases]) The backup functionality in the pe_databases module has been deprecated and will be removed in a future release.`

A notify resource works to output in a Puppet run but results in a change on every Puppet run.

Also added 'warning' note to the readme about the deprecation.