### PR TITLE
(SUP-2682) Remove Requires= property from timers

### DIFF
--- a/templates/timer.epp
+++ b/templates/timer.epp
@@ -1,7 +1,6 @@
 <%- | String $tables, String $on_cal | -%>
 [Unit]
 Description=Timer to trigger repacking PE database tables
-Requires=pe_databases-<%= $tables %>.service
 
 [Timer]
 OnCalendar=<%= $on_cal %>


### PR DESCRIPTION
Prior to this commit, this property created an unwanted dependency
between the timer and service. The effect is that starting the timer
will immediately start the service regardless of the schedule. Removing
this property allows the implicit relationships to work properly.