### PR TITLE
(SUP-2557) Ensure backup class is not included by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,9 @@ class pe_databases (
           include pe_databases::postgresql_settings::table_settings
         }
       }
-      if defined('$manage_database_backups') {
+      # Because this parameter is a value of undef with a data type of Undef,
+      # We can the NotUndef type to determine if the value has been set
+      if $manage_database_backups =~ NotUndef {
         class { 'pe_databases::backup':
           disable_maintenance => ! $manage_database_backups,
         }

--- a/spec/acceptance/backup_spec.rb
+++ b/spec/acceptance/backup_spec.rb
@@ -11,10 +11,4 @@ describe 'pe_databases with manage database backups' do
     # Run it twice and test for idempotency
     idempotent_apply(pp)
   end
-  it 'checks if backup cron jobs are up' do
-    run_shell('crontab -l -u pe-postgres') do |r|
-      expect(r.stdout).to match(%r{pe-activity, pe-classifier, pe-inventory, pe-orchestrator, pe-postgres, pe-rbac})
-      expect(r.stdout).to match(%r{pe-puppetdb})
-    end
-  end
 end

--- a/spec/classes/backup_spec.rb
+++ b/spec/classes/backup_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'pe_databases::backup' do
+  context 'when backing up tables' do
+    let (:pre_condition) {'include pe_databases'}
+    it {
+      # I have no idea how this works, but these are the resources we should end up with
+      is_expected.to contain_cron('puppet_enterprise_database_backup_[pe-activity, pe-classifier, pe-inventory, pe-orchestrator, pe-postgres, pe-rbac]')
+      is_expected.to contain_cron('puppet_enterprise_database_backup_[pe-puppetdb]')
+    }
+  end
+end

--- a/spec/classes/backup_spec.rb
+++ b/spec/classes/backup_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'pe_databases::backup' do
   context 'when backing up tables' do
-    let (:pre_condition) {'include pe_databases'}
+    let(:pre_condition) { 'include pe_databases' }
+
     it {
       # I have no idea how this works, but these are the resources we should end up with
       is_expected.to contain_cron('puppet_enterprise_database_backup_[pe-activity, pe-classifier, pe-inventory, pe-orchestrator, pe-postgres, pe-rbac]')

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,14 +1,6 @@
 require 'spec_helper'
 
 describe 'pe_databases' do
-  let(:params) do
-    {
-      manage_database_backups:  false,
-      manage_postgresql_settings: false,
-      manage_table_settings:  false,
-    }
-  end
-
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
@@ -31,5 +23,14 @@ describe 'pe_databases' do
     let(:facts) { { pe_databases: { have_systemd: false } } }
 
     it { is_expected.to contain_notify('pe_databases_systemd_warn') }
+  end
+
+  context 'backups are not included by default' do
+    it { is_expected.to_not contain_class('pe_databases::backup') }
+  end
+
+  context 'backups are included if configured' do
+    let(:params) { {manage_database_backups: true} }
+    it { is_expected.to contain_class('pe_databases::backup') }
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -26,11 +26,12 @@ describe 'pe_databases' do
   end
 
   context 'backups are not included by default' do
-    it { is_expected.to_not contain_class('pe_databases::backup') }
+    it { is_expected.not_to contain_class('pe_databases::backup') }
   end
 
   context 'backups are included if configured' do
-    let(:params) { {manage_database_backups: true} }
+    let(:params) { { manage_database_backups: true } }
+
     it { is_expected.to contain_class('pe_databases::backup') }
   end
 end


### PR DESCRIPTION
Prior to this commit, by default the pe_databases::backup class would be
included but not do anything.  That was because the logic for the class
parameter was correct

disable_maintenance => ! $manage_database_backups

But the logic to include the class was not

if defined('$manage_database_backups')

This commit fixes this logic and adds spec tests to cover it.  I also
moved the test for checking the cron resources from an acceptance test
to spec.