### PR TITLE
(SUP-2677) Deprecate backup functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ It is not recommended to classify using a pre-existing node group in the PE Cons
 
 ### Backup Schedule
 
+> WARNING: The backup functionality in this module has been deprecated and will be removed in a future release. 
+Please refer to the [PE Backup and Restore documentation](https://puppet.com/docs/pe/latest/backing_up_and_restoring_pe.html) for details on how to backup.
+You should ensure the parameter `pe_databases::manage_database_backups` and any parameters from the `pe_databases::backup` class are removed from classification or hiera.
+You should also clean up associated crontab entries.
+
 Backups are not activated by default but can be enabled by setting the following parameter:
 
 Hiera classification example 
@@ -89,6 +94,11 @@ This module attempts to provide default settings that accommodate both a Monolit
 Those defaults change based on the `$all_in_one_pe` parameter.
 
 ## Backups
+
+> WARNING: The backup functionality in this module has been deprecated and will be removed in a future release. 
+Please refer to the [PE Backup and Restore documentation](https://puppet.com/docs/pe/latest/backing_up_and_restoring_pe.html) for details on how to backup.
+You should ensure the parameter `pe_databases::manage_database_backups` and any parameters from the `pe_databases::backup` class are removed from classification or hiera.
+You should also clean up associated crontab entries.
 
 This is the documentation for Pupet Enterprise backups:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,7 @@ class pe_databases (
         class { 'pe_databases::backup':
           disable_maintenance => ! $manage_database_backups,
         }
-        notify { 'pe_databases_backup__deprecate_warn':
+        notify { 'pe_databases_backup_deprecate_warn':
           message  => 'The backup functionality in the pe_databases module has been deprecated and will be removed in a future release',
           loglevel => warning,
         }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,10 @@ class pe_databases (
         class { 'pe_databases::backup':
           disable_maintenance => ! $manage_database_backups,
         }
+        notify { 'pe_databases_backup__deprecate_warn':
+          message  => 'The backup functionality in the pe_databases module has been deprecated and will be removed in a future release',
+          loglevel => warning,
+        }
       }
     }
     else {

--- a/spec/acceptance/backup_spec.rb
+++ b/spec/acceptance/backup_spec.rb
@@ -9,6 +9,7 @@ describe 'pe_databases with manage database backups' do
        MANIFEST
 
     # Expect a change due to backup notify
+    apply_manifest(pp)
     apply_manifest(pp, expect_changes: true)
   end
 end

--- a/spec/acceptance/backup_spec.rb
+++ b/spec/acceptance/backup_spec.rb
@@ -8,7 +8,7 @@ describe 'pe_databases with manage database backups' do
        }#{' '}
        MANIFEST
 
-    # Run it twice and test for idempotency
-    idempotent_apply(pp)
+    # Expect a change due to backup notify
+    apply_manifest(pp, expect_changes: true)
   end
 end


### PR DESCRIPTION
If the parameter pe_databases::manage_database_backups is set (to true or false) a notify warning is displayed on Puppet runs about deprecation and removing this param.
This warning doesn't come up if this parameter is not set. 

Note added to readme regarding the deprecation.