### PR TITLE
(SUP-3972) Add activity tables to repack

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,24 @@
+pe_databases::facts_tables_repack_timer:
+  'Tue,Sat *-*-* 04:30:00'
+pe_databases::catalogs_tables_repack_timer:
+  'Sun,Thu *-*-* 04:30:00'
+pe_databases::other_tables_repack_timer:
+  '*-*-20 05:30:00'
+pe_databases::activity_tables_repack_timer:
+  'Wed,Fri *-*-* 04:30:00'
+pe_databases::pg_repack::fact_tables:
+  - factsets
+  - fact_paths
+pe_databases::pg_repack::catalog_tables:
+  - catalogs
+  - catalog_resources
+  - catalog_inputs
+  - edges
+  - certnames
+pe_databases::pg_repack::other_tables:
+  - producers
+  - resource_params
+  - resource_params_cache
+pe_databases::pg_repack::activity_tables:
+  - events
+  - event_commits

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,10 @@
+---
+version: 5
+
+defaults:  # Used for any hierarchy level that omits these keys.
+  datadir: data         # This path is relative to hiera.yaml's directory.
+  data_hash: yaml_data  # Use the built-in YAML backend.
+
+hierarchy:
+  - name: 'common'
+    path: 'common.yaml'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,20 +9,23 @@
 # @param facts_tables_repack_timer [String] The Systemd timer for the pg_repack job affecting the 'facts' tables
 # @param catalogs_tables_repack_timer [String]The Systemd timer for the pg_repack job affecting the 'catalog' tables
 # @param other_tables_repack_timer [String] The Systemd timer for the pg_repack job affecting the 'other' tables
+# @param activity_tables_repack_timer [String] The Systemd timer for the pg_repack job affecting the 'activity' tables
 # @param manage_postgresql_settings [Boolean] Deprecated Parameter will be removed in future releases
 # @param manage_table_settings [Boolean] Deprecated Parameter will be removed in future releases
 # @param reports_tables_repack_timer [String] Deprecated Parameter will be removed in future releases
 # @param resource_events_tables_repack_timer [String] Deprecated Parameter will be removed in future releases
 class pe_databases (
+  # Provided by module data
+  String[1] $facts_tables_repack_timer,
+  String[1] $catalogs_tables_repack_timer,
+  String[1] $other_tables_repack_timer,
+  String[1] $activity_tables_repack_timer,
   Boolean $manage_database_maintenance           = true,
   Boolean $disable_maintenance                   = false,
   Optional[Boolean] $manage_postgresql_settings  = undef,
   Optional[Boolean] $manage_table_settings       = undef,
   String[1] $install_dir                         = '/opt/puppetlabs/pe_databases',
   String[1] $scripts_dir                         = "${install_dir}/scripts",
-  String[1] $facts_tables_repack_timer           = 'Tue,Sat *-*-* 04:30:00',
-  String[1] $catalogs_tables_repack_timer        = 'Sun,Thu *-*-* 04:30:00',
-  String[1] $other_tables_repack_timer           = '*-*-20 05:30:00',
   Optional[String] $reports_tables_repack_timer         = undef,
   Optional[String] $resource_events_tables_repack_timer = undef,
 ) {

--- a/spec/defines/collect_spec.rb
+++ b/spec/defines/collect_spec.rb
@@ -13,6 +13,7 @@ describe 'pe_databases::collect' do
       {
         command: 'foo',
         on_cal: 'bar',
+        tables: ['baz'],
       }
     end
 
@@ -22,7 +23,7 @@ describe 'pe_databases::collect' do
 
       is_expected.to contain_file('/etc/systemd/system/pe_databases-test.timer').with_content(%r{bar})
       is_expected.to contain_file('/etc/systemd/system/pe_databases-test.service').with_content(
-        %r{ExecStart=foo},
+        %r{ExecStart=foo.*-t baz},
       )
 
       is_expected.to contain_service('pe_databases-test.service').that_notifies(
@@ -47,6 +48,7 @@ describe 'pe_databases::collect' do
         disable_maintenance: true,
         command: 'foo',
         on_cal: 'bar',
+        tables: ['baz'],
       }
     end
 


### PR DESCRIPTION
This commit adds a new service and timer to repack tables in the pe-activity database.  It also moves a few parameters to module data.