### PR TITLE
(SUP-4666) Pe_databases: pg_repack enable debug mode

### DIFF
--- a/data/rspec.yaml
+++ b/data/rspec.yaml
@@ -1,0 +1,26 @@
+pe_databases::facts_tables_repack_timer:
+  'Tue,Sat *-*-* 04:30:00'
+pe_databases::catalogs_tables_repack_timer:
+  'Sun,Thu *-*-* 04:30:00'
+pe_databases::other_tables_repack_timer:
+  '*-*-20 05:30:00'
+pe_databases::activity_tables_repack_timer:
+  'Wed,Fri *-*-* 04:30:00'
+pe_databases::pg_repack::fact_tables:
+  - factsets
+  - fact_paths
+pe_databases::pg_repack::catalog_tables:
+  - catalogs
+  - catalog_resources
+  - catalog_inputs
+  - edges
+  - certnames
+pe_databases::pg_repack::other_tables:
+  - producers
+  - resource_params
+  - resource_params_cache
+pe_databases::pg_repack::activity_tables:
+  - events
+  - event_commits
+pe_databases::pg_repack::repack_log_level: 'INFO'
+pe_databases::pg_repack::enable_echo: false

--- a/hiera-rspec.yaml
+++ b/hiera-rspec.yaml
@@ -1,0 +1,10 @@
+---
+version: 5
+
+defaults:  # Used for any hierarchy level that omits these keys.
+  datadir: data         # This path is relative to hiera.yaml's directory.
+  data_hash: yaml_data  # Use the built-in YAML backend.
+
+hierarchy:
+  - name: 'rspec'
+    path: 'rspec.yaml'


### PR DESCRIPTION
Implementation of the new conditional logic to enable DEBUG and echo by default in `pg-repack.pp`, this is set by two new variables which by default are configured to:

`Enum['INFO','NOTICE','WARNING', 'ERROR', 'LOG', 'FATAL','PANIC','DEBUG'] $repack_run_level='DEBUG',
  Boolean $enable_echo = true,`
  
For configuration of $repack_run_level, change DEBUG too one of the stored options:
`Enum['INFO','NOTICE','WARNING', 'ERROR', 'LOG', 'FATAL','PANIC','DEBUG'] $repack_run_level=<option>` and receive the relevant output in .service files

And to disable echo set `$enable_echo` to `false`
